### PR TITLE
[Q-3]: Added ERC165 support

### DIFF
--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -8,6 +8,9 @@ import "openzeppelin-contracts/interfaces/IERC1271.sol";
 import "openzeppelin-contracts/utils/cryptography/SignatureChecker.sol";
 import "openzeppelin-contracts/utils/Address.sol";
 
+import "openzeppelin-contracts/utils/introspection/IERC165.sol";
+import "openzeppelin-contracts/token/ERC1155/IERC1155Receiver.sol";
+
 import "./MinimalReceiver.sol";
 import "./interfaces/IVault.sol";
 import "./lib/MinimalProxyStore.sol";
@@ -161,6 +164,26 @@ contract Vault is IVault, MinimalReceiver {
         }
 
         return "";
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155Receiver)
+        returns (bool)
+    {
+        // default interface support
+        if (
+            interfaceId == type(IVault).interfaceId ||
+            interfaceId == type(IERC1155Receiver).interfaceId ||
+            interfaceId == type(IERC165).interfaceId
+        ) {
+            return true;
+        }
+
+        // if interface is not supported by default, check executor
+        return IERC165(executor[owner()]).supportsInterface(interfaceId);
     }
 
     /**


### PR DESCRIPTION
This PR adds ERC165 support that is extensible via a custom executor. Fixes `[Q-3] Implement ERC165 for Vaults` finding in audit report.