### PR TITLE
[G-3] Made vaultImplementation immutable

### DIFF
--- a/src/VaultRegistry.sol
+++ b/src/VaultRegistry.sol
@@ -16,7 +16,7 @@ contract VaultRegistry {
     /**
      * @dev Address of the default vault implementation
      */
-    address public vaultImplementation;
+    address public immutable vaultImplementation;
 
     /**
      * @dev Emitted whenever a vault is created


### PR DESCRIPTION
This PR makes `vaultImplementation` an immutable variable on `VaultRegistry`. This fixes the `[G-3] Multiple vars can be made immutable` audit finding.