### PR TITLE
Make isAuthorized virtual for extension overrides

### DIFF
--- a/src/Account.sol
+++ b/src/Account.sol
@@ -236,7 +236,7 @@ contract Account is
     }
 
     /// @dev Returns the authorization status for a given caller
-    function isAuthorized(address caller) public view returns (bool) {
+    function isAuthorized(address caller) public view virtual returns (bool) {
         // authorize entrypoint for 4337 transactions
         if (caller == _entryPoint) return true;
 


### PR DESCRIPTION
Hey, @jaydenwindle, to be able to override the `isAuthorized` function it would need to be virtual. There might be a better way to go about this, but here's my initial work/thoughts for a delegate extension if you are interested:

https://github.com/CR3Labs/erc-6551-delegate-extension